### PR TITLE
Divide example code and add a .bat file to boot .ps1 file

### DIFF
--- a/EXAMPLE/BootSwitchAudioDevice.bat
+++ b/EXAMPLE/BootSwitchAudioDevice.bat
@@ -1,0 +1,2 @@
+start powershell -file .\SwitchAudioDevice.ps1
+exit

--- a/EXAMPLE/PlaySound.ps1
+++ b/EXAMPLE/PlaySound.ps1
@@ -15,19 +15,10 @@ https://github.com/frgnca/AudioDeviceCmdlets
 # Bonus: Run this PowerShell script from a VBScript to avoid visible window
 # Toggle-AudioDevice.vbs
 <#
-command = "powershell.exe -nologo -command C:\Path\To\Toggle-AudioDevice.ps1"
+command = "powershell.exe -nologo -command C:\Path\To\PlaySound.ps1"
 set shell = CreateObject("WScript.Shell")
 shell.Run command,0
 #>
-
-# Define AudioDevice by ID (ex: "{0.0.0.00000000}.{c4aadd95-74c7-4b3b-9508-b0ef36ff71ba}")
-$AudioDevice_A = "{0.0.0.00000000}.{48300fc4-2125-492d-ab28-c6b01b9eee6b}"
-$AudioDevice_B = "{0.0.0.00000000}.{c4aadd95-74c7-4b3b-9508-b0ef36ff71ba}"
-
-# Toggle default playback device
-$DefaultPlayback = Get-AudioDevice -Playback
-If ($DefaultPlayback.ID -eq $AudioDevice_A) {Set-AudioDevice -ID $AudioDevice_B | Out-Null}
-Else {Set-AudioDevice -ID $AudioDevice_A | Out-Null}
 
 # Play sound
 $Sound = new-Object System.Media.SoundPlayer

--- a/EXAMPLE/SwitchAudioDevice.ps1
+++ b/EXAMPLE/SwitchAudioDevice.ps1
@@ -1,0 +1,30 @@
+<#
+Copyright (c) 2016-2022 Francois Gendron <fg@frgn.ca>
+MIT License
+
+This file is a script that toggles between two playback audio devices using 
+AudioDeviceCmdlets then plays a sound for confirmation
+AudioDeviceCmdlets is a suite of PowerShell Cmdlets to control audio devices 
+on Windows
+https://github.com/frgnca/AudioDeviceCmdlets
+#>
+
+# This script toggles between two playback audio devices then plays a sound for confirmation
+# The devices are defined by their ID (Get-AudioDevice -List)
+
+# Bonus: Run this PowerShell script from a VBScript to avoid visible window
+# Toggle-AudioDevice.vbs
+<#
+command = "powershell.exe -nologo -command C:\Path\To\SwitchAudioDevice.ps1"
+set shell = CreateObject("WScript.Shell")
+shell.Run command,0
+#>
+
+# Define AudioDevice by ID (ex: "{0.0.0.00000000}.{c4aadd95-74c7-4b3b-9508-b0ef36ff71ba}")
+$AudioDevice_A = "{0.0.0.00000000}.{48300fc4-2125-492d-ab28-c6b01b9eee6b}"
+$AudioDevice_B = "{0.0.0.00000000}.{c4aadd95-74c7-4b3b-9508-b0ef36ff71ba}"
+
+# Toggle default playback device
+$DefaultPlayback = Get-AudioDevice -Playback
+If ($DefaultPlayback.ID -eq $AudioDevice_A) {Set-AudioDevice -ID $AudioDevice_B | Out-Null}
+Else {Set-AudioDevice -ID $AudioDevice_A | Out-Null}


### PR DESCRIPTION
Divided an example file which contains two kinds of code.
Added a .bat file booting .ps1 file to be able to switch speaker and headphone easily.